### PR TITLE
[appveyor] Fix coverage by installing sdist version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,13 @@ build_script:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;;%PATH%"
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
-  - "pip install ."
   - "pip install -Ur test-requirements.txt"
   - "pip install codecov"
+  - "python setup.py sdist --formats=zip"
+  - "python -c \"import async_generator; print(async_generator.__version__)\" > version.txt"
+  - "set /p VERSION=<version.txt"
+  - "pip install dist\\async_generator-%VERSION%.zip"
 
 test_script:
-  - py.test -ra --pyargs async_generator --cov=async_generator --cov-config=.coveragerc
-  - codecov
+  - "pytest -ra --pyargs async_generator --cov=\"%PYTHON%\\lib\\site-packages\\async_generator\" --cov-config=.coveragerc"
+  - "codecov"


### PR DESCRIPTION
This is closer to what we do in Travis. However, `async_generator.__file__` was not pointing to the correct path (shown by `pip show -f async_generator`), so I decided to build it manually. This is probably quite brittle, but at least it currently works.

Fixes #6.